### PR TITLE
fix: last record transcription repeat on resume recording

### DIFF
--- a/lib/features/voice_record_entry/cubit/voice_record_entry_cubit.dart
+++ b/lib/features/voice_record_entry/cubit/voice_record_entry_cubit.dart
@@ -94,6 +94,7 @@ class VoiceRecordEntryCubit extends Cubit<VoiceRecordEntryState> {
                 state.recordingTranscription.isEmpty)
             ? ''
             : '${state.transcription} ${state.recordingTranscription}',
+        recordingTranscription: '',
       ),
     );
   }
@@ -127,6 +128,7 @@ class VoiceRecordEntryCubit extends Cubit<VoiceRecordEntryState> {
                 state.recordingTranscription.isEmpty)
             ? ''
             : '${state.transcription} ${state.recordingTranscription}',
+        recordingTranscription: '',
       ),
     );
   }


### PR DESCRIPTION
Fix recordinTranscription does not reset on pause or stop recording.